### PR TITLE
Add full text search support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unowned-ai/recall
 
-go 1.24.2
+go 1.23
 
 replace github.com/unowned-ai/recall/pkg/tui => ./pkg/tui
 

--- a/pkg/memories/search.go
+++ b/pkg/memories/search.go
@@ -18,7 +18,7 @@ type MatchedEntry struct {
 // SearchEntriesByTagMatchSQL searches for entries in a specific journal that match the given query tags.
 // Entries are ranked by the number of matching tags in descending order.
 // Only non-deleted entries with at least one matching tag are returned.
-func SearchEntriesByTagMatchSQL(ctx context.Context, db *sql.DB, journalID uuid.UUID, queryTags []string) ([]MatchedEntry, error) {
+func searchEntriesByTagMatchSQL(ctx context.Context, db *sql.DB, journalID uuid.UUID, queryTags []string) ([]MatchedEntry, error) {
 	if len(queryTags) == 0 {
 		return []MatchedEntry{}, nil // No tags to search for, return empty result.
 	}
@@ -88,4 +88,80 @@ func SearchEntriesByTagMatchSQL(ctx context.Context, db *sql.DB, journalID uuid.
 	}
 
 	return results, nil
+}
+
+// searchEntriesFullText performs a full text search combined with optional tag filtering.
+// If queryTags is empty, no tag filtering is applied. textQuery must be non-empty.
+// Results are ordered by the FTS rank and then by match count of tags.
+func searchEntriesFullText(ctx context.Context, db *sql.DB, journalID uuid.UUID, queryTags []string, textQuery string) ([]MatchedEntry, error) {
+	if strings.TrimSpace(textQuery) == "" {
+		return nil, fmt.Errorf("textQuery must be non-empty for full text search")
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`SELECT
+                e.id, e.journal_id, e.title, e.content, e.content_type, e.deleted, e.created_at, e.updated_at,
+                COUNT(et.tag) as match_count,
+                bm25(f) as rank
+        FROM entries e
+        JOIN entries_fts f ON e.id = f.entry_id
+        LEFT JOIN entry_tags et ON e.id = et.entry_id`)
+
+	var args []interface{}
+	if len(queryTags) > 0 {
+		placeholders := strings.Repeat("?,", len(queryTags)-1) + "?"
+		sb.WriteString(" AND et.tag IN (" + placeholders + ")")
+		for _, t := range queryTags {
+			args = append(args, t)
+		}
+	}
+
+	sb.WriteString(`
+        WHERE e.journal_id = ? AND e.deleted = FALSE AND f MATCH ?
+        GROUP BY e.id, e.journal_id, e.title, e.content, e.content_type, e.deleted, e.created_at, e.updated_at
+        ORDER BY rank, match_count DESC, e.updated_at DESC;`)
+
+	args = append(args, journalID, textQuery)
+
+	rows, err := db.QueryContext(ctx, sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute full text search query: %w", err)
+	}
+	defer rows.Close()
+
+	var results []MatchedEntry
+	for rows.Next() {
+		var me MatchedEntry
+		var rank float64
+		err := rows.Scan(
+			&me.Entry.ID,
+			&me.Entry.JournalID,
+			&me.Entry.Title,
+			&me.Entry.Content,
+			&me.Entry.ContentType,
+			&me.Entry.Deleted,
+			&me.Entry.CreatedAt,
+			&me.Entry.UpdatedAt,
+			&me.MatchCount,
+			&rank,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan search result row: %w", err)
+		}
+		results = append(results, me)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over search results: %w", err)
+	}
+	return results, nil
+}
+
+// SearchEntries returns entries matching tags and/or full text.
+// If textQuery is empty, the search is performed by tags only.
+// When textQuery is provided, full text search is used with optional tag filtering.
+func SearchEntries(ctx context.Context, db *sql.DB, journalID uuid.UUID, queryTags []string, textQuery string) ([]MatchedEntry, error) {
+	if strings.TrimSpace(textQuery) != "" {
+		return searchEntriesFullText(ctx, db, journalID, queryTags, textQuery)
+	}
+	return searchEntriesByTagMatchSQL(ctx, db, journalID, queryTags)
 }

--- a/pkg/tui/go.mod
+++ b/pkg/tui/go.mod
@@ -1,6 +1,6 @@
 module github.com/unowned-ai/recall/pkg/tui
 
-go 1.24.2
+go 1.23
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0


### PR DESCRIPTION
## Summary
- support FTS table and triggers in the DB schema
- ensure FTS objects are present when upgrading the DB
- refactor to a single `SearchEntries` API handling text and tag searches
- extend CLI and MCP search commands to use the unified search
- add basic full text search test
- downgrade Go version to 1.23 for offline builds

## Testing
- ❌ `go fmt ./...` *(failed: no route to host)*
- ❌ `go test ./... -count=1 -v` *(failed: no route to host)*
